### PR TITLE
Fix cross-platform keyboard dismissal

### DIFF
--- a/WoWBud/SpellLookupView.swift
+++ b/WoWBud/SpellLookupView.swift
@@ -1,4 +1,9 @@
 import SwiftUI
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
 
 /// View for looking up spell details by ID.
 struct SpellLookupView: View {
@@ -79,9 +84,8 @@ struct SpellLookupView: View {
 
     /// Fetches spell data using the DataBridge.
     private func fetchSpell() async {
-        // Hide keyboard
-        UIApplication.shared.sendAction(
-            #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        // Hide keyboard using a platform agnostic helper
+        hideKeyboard()
 
         // Reset state before fetching
         errorMessage = nil
@@ -122,6 +126,18 @@ struct SpellLookupView: View {
         }
 
         isLoading = false  // Stop loading indicator
+    }
+
+    /// Dismisses the keyboard across platforms.
+    private func hideKeyboard() {
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+        // macOS: resign first responder for the key window
+        DispatchQueue.main.async { NSApp.keyWindow?.makeFirstResponder(nil) }
+#elseif canImport(UIKit)
+        // iOS: send resign action globally
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary
- fix SpellLookupView so it builds on macOS
- add cross-platform keyboard hiding helper

## Testing
- `swift build` *(fails: Could not find Package.swift)*

## Summary by Sourcery

Add conditional AppKit/ UIKit imports and centralize keyboard dismissal in a hideKeyboard() helper to support both iOS and macOS

Bug Fixes:
- Restore build compatibility for SpellLookupView on macOS
- Ensure keyboard dismissal works correctly on both iOS and macOS

Enhancements:
- Introduce a cross-platform hideKeyboard() helper to abstract keyboard dismissal logic
- Refactor inline keyboard hide call to use the new platform-agnostic helper