### PR TITLE
Fix invalid weapon icon

### DIFF
--- a/WoWBud/ClassBrowserView.swift
+++ b/WoWBud/ClassBrowserView.swift
@@ -1222,8 +1222,8 @@ enum WeaponType: String, CaseIterable, Identifiable {
     var iconName: String {
         switch self {
         case .dagger: return "scissors"
-        case .oneHandedSword: return "slash"
-        case .twoHandedSword: return "slash.circle"
+        case .oneHandedSword: return "sword"
+        case .twoHandedSword: return "sword.circle"
         case .oneHandedMace: return "hammer"
         case .twoHandedMace: return "hammer.circle"
         case .oneHandedAxe: return "scissors"


### PR DESCRIPTION
## Summary
- use a valid SFSymbol for sword weapon types
- add fallback to classic-era namespace if 1.x item not found

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_682e124a1d0c83328d74fe16e0b377ef

## Summary by Sourcery

Add multi-stage fallback for item fetching across Classic API namespaces and correct invalid SF Symbols for sword weapon icons

Bug Fixes:
- Fix invalid SF Symbols for one-handed and two-handed sword icons

Enhancements:
- Add fallback logic in ClassicAPIService to retry item requests across classic1x, classic-era, and classic namespaces
- Improve logging around item fetch attempts and errors